### PR TITLE
useEffectとuseFocusEffectを完全削除してイベントドリブン方式に変更

### DIFF
--- a/ReMeet/app/person-register.tsx
+++ b/ReMeet/app/person-register.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Alert } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
@@ -15,26 +15,28 @@ import type { CreatePersonData } from '@/database/sqlite-services';
 export default function PersonRegisterScreen() {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [availableTags, setAvailableTags] = useState<string[]>([]);
+  const [availableTags, setAvailableTags] = useState<string[]>([
+    'フロントエンド', 'バックエンド', 'React', 'TypeScript', 'JavaScript', 
+    'Python', 'Node.js', 'デザイナー', 'エンジニア', 'プロダクトマネージャー'
+  ]);
+  const [tagsLoaded, setTagsLoaded] = useState(false);
 
-  // コンポーネントマウント時に既存タグを読み込み
-  useEffect(() => {
-    const loadAvailableTags = async () => {
-      try {
-        const tags = await TagService.findAll();
-        setAvailableTags(tags.map(tag => tag.name));
-      } catch (error) {
-        console.error('Failed to load available tags:', error);
-        // エラー時はデフォルトタグを設定
-        setAvailableTags([
-          'フロントエンド', 'バックエンド', 'React', 'TypeScript', 'JavaScript', 
-          'Python', 'Node.js', 'デザイナー', 'エンジニア', 'プロダクトマネージャー'
-        ]);
-      }
-    };
+  /**
+   * 既存タグを読み込む関数
+   */
+  const loadAvailableTags = async () => {
+    if (tagsLoaded) return; // 既に読み込み済みの場合はスキップ
     
-    loadAvailableTags();
-  }, []);
+    try {
+      const tags = await TagService.findAll();
+      setAvailableTags(tags.map(tag => tag.name));
+      setTagsLoaded(true);
+    } catch (error) {
+      console.error('Failed to load available tags:', error);
+      // エラー時はデフォルトタグを保持
+      setTagsLoaded(true);
+    }
+  };
 
   /**
    * 新規タグ追加処理
@@ -145,6 +147,7 @@ export default function PersonRegisterScreen() {
         isSubmitting={isSubmitting}
         availableTags={availableTags}
         onNewTagsAdded={handleNewTagsAdded}
+        onTagsInputFocus={loadAvailableTags}
       />
     </ThemedView>
   );

--- a/ReMeet/components/forms/PersonRegistrationForm.tsx
+++ b/ReMeet/components/forms/PersonRegistrationForm.tsx
@@ -27,6 +27,8 @@ export interface PersonRegistrationFormProps {
   availableTags?: string[];
   /** 新規タグ登録時のコールバック */
   onNewTagsAdded?: (newTags: string[]) => void;
+  /** タグ入力フィールドフォーカス時のコールバック */
+  onTagsInputFocus?: () => void;
 }
 
 /**
@@ -39,7 +41,8 @@ export function PersonRegistrationForm({
   isSubmitting = false,
   initialData,
   availableTags = [],
-  onNewTagsAdded
+  onNewTagsAdded,
+  onTagsInputFocus
 }: PersonRegistrationFormProps) {
   
   // フォーム送信時に新規タグを登録
@@ -234,6 +237,7 @@ export function PersonRegistrationForm({
                 value={tagsArray}
                 onChangeText={handleTagsChange}
                 onBlur={onBlur}
+                onFocus={onTagsInputFocus}
                 availableTags={availableTags}
                 error={errors.tags?.message}
                 placeholder="タグを入力してEnterキーを押してください"

--- a/ReMeet/components/forms/TagInputWithSuggestions.tsx
+++ b/ReMeet/components/forms/TagInputWithSuggestions.tsx
@@ -7,6 +7,7 @@ export interface TagInputWithSuggestionsProps {
   value: string[];
   onChangeText: (tags: string[]) => void;
   onBlur?: () => void;
+  onFocus?: () => void;
   availableTags: string[];
   error?: string;
   testID?: string;
@@ -23,6 +24,7 @@ export function TagInputWithSuggestions({
   value,
   onChangeText,
   onBlur,
+  onFocus,
   availableTags,
   error,
   testID,
@@ -93,6 +95,7 @@ export function TagInputWithSuggestions({
           value={inputText}
           onChangeText={setInputText}
           onBlur={onBlur}
+          onFocus={onFocus}
           autoCapitalize="none"
           testID={testID}
         />


### PR DESCRIPTION
## 概要
CLAUDE.mdの禁止事項を厳格に遵守し、useEffectやuseFocusEffectを一切使用しない実装に修正しました。

## 問題
- 前回の実装でuseEffectを使用していた（CLAUDE.md禁止事項違反）
- useFocusEffectも内部的にuseEffectを使用するため同様に問題

## 解決方法
**イベントドリブン方式**への変更により、useEffect系を完全排除

### 実装変更点

#### **app/person-register.tsx**
- useEffect/useFocusEffect削除
- デフォルト値による初期状態設定
- タグ入力フィールドフォーカス時の動的読み込み関数実装

#### **TagInputWithSuggestions.tsx** 
- onFocusプロパティ追加
- 親コンポーネントからのコールバック対応

#### **PersonRegistrationForm.tsx**
- onTagsInputFocusプロパティ追加
- タグ入力フィールドと親の読み込み関数を連携

## 動作フロー
1. 初期状態：デフォルトタグでの初期化
2. ユーザーがタグ入力フィールドをフォーカス
3. onFocusイベントでTagService.findAll()を実行
4. 既存タグ一覧を動的に更新

## 技術的利点
- **CLAUDE.mdガイドライン完全準拠**
- **技術的負債の排除**
- **不要なレンダリングの防止**
- **イベントドリブンによる明確な制御**

## 品質確保
- PersonRegistrationFormテスト: **12/12合格** ✅
- Lintチェック: **合格** ✅
- useEffect系の完全排除確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)