### PR TITLE
ホーム画面の簡潔化：表示情報を名前・タグ・出会った場所のみに限定

### DIFF
--- a/ReMeet/__tests__/app/(tabs)/people.test.tsx
+++ b/ReMeet/__tests__/app/(tabs)/people.test.tsx
@@ -94,15 +94,9 @@ describe('HomeScreen', () => {
         }
       });
 
-      // Assert: 人物データが表示されることを確認
+      // Assert: 人物データ（簡潔版）が表示されることを確認
       await waitFor(() => {
         expect(screen.getByText('山田太郎')).toBeTruthy();
-        expect(screen.getByText('@yamada_taro')).toBeTruthy();
-        expect(screen.getByText('株式会社テスト')).toBeTruthy();
-        expect(screen.getByText('エンジニア')).toBeTruthy();
-        expect(screen.getByText('📱 テストアプリ')).toBeTruthy();
-        expect(screen.getByText('💻 yamada-taro')).toBeTruthy();
-        expect(screen.getByText('💭 メモです')).toBeTruthy();
         expect(screen.getByText('📅 React Conference 2024')).toBeTruthy();
         expect(screen.getByText('📍 東京国際フォーラム')).toBeTruthy();
         expect(screen.getByText('React')).toBeTruthy();
@@ -111,7 +105,6 @@ describe('HomeScreen', () => {
 
       await waitFor(() => {
         expect(screen.getByText('佐藤花子')).toBeTruthy();
-        expect(screen.getByText('株式会社サンプル')).toBeTruthy();
       });
 
       // 人数表示の確認
@@ -234,12 +227,11 @@ describe('HomeScreen', () => {
         expect(screen.getByText('1人が登録されています')).toBeTruthy();
       });
 
-      // オプション項目は表示されないことを確認
+      // 簡潔版では表示されない項目を確認（handle、company、positionなど）
+      expect(screen.queryByText('@')).toBeNull();
       expect(screen.queryByText('📱')).toBeNull();
       expect(screen.queryByText('💻')).toBeNull();
       expect(screen.queryByText('💭')).toBeNull();
-      expect(screen.queryByText('📅')).toBeNull();
-      expect(screen.queryByText('📍')).toBeNull();
     });
 
     it('タグが複数ある場合に正しく表示される', async () => {

--- a/ReMeet/app/(tabs)/people.tsx
+++ b/ReMeet/app/(tabs)/people.tsx
@@ -84,52 +84,17 @@ export default function HomeScreen() {
   }
 
   /**
-   * 人物カードコンポーネント
-   * 各人物の情報を表示するカード
+   * 人物カードコンポーネント（簡潔版）
+   * 名前、タグ、どこであったかのみ表示
    */
   const PersonCard = ({ person }: { person: PersonWithRelations }) => (
     <ThemedView style={styles.personCard}>
-      {/* 名前とハンドル */}
+      {/* 名前 */}
       <View style={styles.nameContainer}>
         <ThemedText type="subtitle" style={styles.name}>
           {person.name}
         </ThemedText>
-        {person.handle && (
-          <ThemedText style={styles.handle}>
-            {person.handle}
-          </ThemedText>
-        )}
       </View>
-
-      {/* 会社・役職 */}
-      {(person.company || person.position) && (
-        <View style={styles.workContainer}>
-          {person.company && (
-            <ThemedText style={styles.company}>
-              {person.company}
-            </ThemedText>
-          )}
-          {person.position && (
-            <ThemedText style={styles.position}>
-              {person.position}
-            </ThemedText>
-          )}
-        </View>
-      )}
-
-      {/* プロダクト名 */}
-      {person.productName && (
-        <ThemedText style={styles.productName}>
-          📱 {person.productName}
-        </ThemedText>
-      )}
-
-      {/* GitHub ID */}
-      {person.githubId && (
-        <ThemedText style={styles.githubId}>
-          💻 {person.githubId}
-        </ThemedText>
-      )}
 
       {/* タグ */}
       {person.tags && person.tags.length > 0 && (
@@ -152,11 +117,6 @@ export default function HomeScreen() {
               <ThemedText style={styles.eventName}>
                 📅 {event.name}
               </ThemedText>
-              {event.date && (
-                <ThemedText style={styles.eventDate}>
-                  {new Date(event.date).toLocaleDateString('ja-JP')}
-                </ThemedText>
-              )}
               {event.location && (
                 <ThemedText style={styles.eventLocation}>
                   📍 {event.location}
@@ -166,18 +126,6 @@ export default function HomeScreen() {
           ))}
         </View>
       )}
-
-      {/* メモ（その人の特徴） */}
-      {person.memo && (
-        <ThemedText style={styles.memo} numberOfLines={2}>
-          💭 {person.memo}
-        </ThemedText>
-      )}
-
-      {/* 登録日 */}
-      <ThemedText style={styles.date}>
-        登録日: {new Date(person.createdAt).toLocaleDateString('ja-JP')}
-      </ThemedText>
     </ThemedView>
   );
 
@@ -346,45 +294,16 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   nameContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8,
+    marginBottom: 12,
   },
   name: {
     fontSize: 18,
     fontWeight: 'bold',
-    marginRight: 8,
-  },
-  handle: {
-    opacity: 0.6,
-    fontSize: 14,
-  },
-  workContainer: {
-    marginBottom: 8,
-  },
-  company: {
-    fontSize: 16,
-    fontWeight: '500',
-    marginBottom: 2,
-  },
-  position: {
-    opacity: 0.7,
-    fontSize: 14,
-  },
-  productName: {
-    fontSize: 14,
-    marginBottom: 4,
-    opacity: 0.8,
-  },
-  githubId: {
-    fontSize: 14,
-    marginBottom: 8,
-    opacity: 0.8,
   },
   tagsContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginBottom: 8,
+    marginBottom: 12,
   },
   tag: {
     backgroundColor: 'rgba(0, 122, 255, 0.1)',
@@ -399,19 +318,8 @@ const styles = StyleSheet.create({
     color: '#007AFF',
     fontWeight: '500',
   },
-  memo: {
-    fontSize: 14,
-    opacity: 0.7,
-    marginBottom: 8,
-    fontStyle: 'italic',
-  },
-  date: {
-    fontSize: 12,
-    opacity: 0.5,
-    textAlign: 'right',
-  },
   eventsContainer: {
-    marginBottom: 8,
+    // marginBottomを削除して最後の要素として扱う
   },
   eventCard: {
     backgroundColor: 'rgba(76, 175, 80, 0.1)',
@@ -423,11 +331,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
     color: '#4CAF50',
-    marginBottom: 2,
-  },
-  eventDate: {
-    fontSize: 12,
-    opacity: 0.7,
     marginBottom: 2,
   },
   eventLocation: {


### PR DESCRIPTION
## 概要
ホーム画面のPersonCardコンポーネントを簡潔化し、最も重要な情報のみを表示するように修正しました。

## 変更内容
- **表示項目の絞り込み**:
  - 名前（name）
  - タグ（tags）
  - 出会った場所・イベント（events）

- **削除した項目**:
  - handle（@ユーザー名）
  - company（会社名）
  - position（役職）
  - productName（プロダクト名）
  - githubId（GitHub ID）
  - memo（メモ）
  - 登録日（createdAt）

## スタイルの最適化
- 不要なスタイル定義を削除
- 簡潔版レイアウトに最適化したマージン設定
- 視認性を向上させるための余白調整

## テストの更新
- 簡潔版に合わせてテストケースを修正
- 表示されなくなった項目のテストを削除
- 新しいレイアウトに対応

## 確認済み
- ✅ 全テスト通過（97件）
- ✅ Lintチェック通過  
- ✅ Buildチェック通過

## テスト計画
- [ ] `npm start --tunnel` を実行してQRコードを確認
- [ ] ホーム画面で名前・タグ・出会った場所のみが表示されることを確認
- [ ] レイアウトが適切に表示されることを確認
- [ ] 人物追加機能が正常に動作することを確認