### PR TITLE
PersonService update関数実装エラーの修正

### DIFF
--- a/ReMeet/__tests__/database/sqlite-services/PersonService.test.ts
+++ b/ReMeet/__tests__/database/sqlite-services/PersonService.test.ts
@@ -1,0 +1,306 @@
+import { PersonService } from '../../../database/sqlite-services/PersonService';
+import { TagService } from '../../../database/sqlite-services/TagService';
+import type { UpdatePersonData } from '../../../database/sqlite-services/PersonService';
+import type { PersonWithRelations } from '../../../database/sqlite-types';
+
+describe('PersonService', () => {
+  // テスト用のモックデータ
+  const mockTestPersons: PersonWithRelations[] = [
+    {
+      id: 'test-person-1',
+      name: 'テスト太郎',
+      handle: '@test_taro',
+      company: 'テスト会社',
+      position: 'エンジニア',
+      description: 'テスト用の人物です',
+      productName: 'テストプロダクト',
+      memo: 'テスト用メモ',
+      githubId: 'test-taro',
+      createdAt: new Date('2025-01-01'),
+      updatedAt: new Date('2025-01-01'),
+      tags: [
+        { id: 'tag-1', name: 'React' },
+        { id: 'tag-2', name: 'TypeScript' },
+      ],
+      events: [],
+      relations: [],
+    },
+    {
+      id: 'test-person-2',
+      name: 'テスト花子',
+      handle: '@test_hanako',
+      company: 'テスト株式会社',
+      position: 'デザイナー',
+      description: 'UI/UXデザイナー',
+      productName: 'デザインツール',
+      memo: 'デザイン関連のテストユーザー',
+      githubId: null,
+      createdAt: new Date('2025-01-02'),
+      updatedAt: new Date('2025-01-02'),
+      tags: [
+        { id: 'tag-3', name: 'UI/UX' },
+        { id: 'tag-4', name: 'Figma' },
+      ],
+      events: [],
+      relations: [],
+    },
+  ];
+
+  // 各テストの前にモックデータをセットアップ
+  beforeEach(() => {
+    PersonService.clearMockData();
+    PersonService.addMockData([...mockTestPersons]);
+  });
+
+  // 各テストの後にモックデータをクリア
+  afterEach(() => {
+    PersonService.clearMockData();
+  });
+
+  describe('update', () => {
+    it('存在する人物の基本情報を更新できる', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: '更新された太郎',
+        handle: '@updated_taro',
+        company: '更新された会社',
+        position: '更新されたポジション',
+        description: '更新された説明',
+        productName: '更新されたプロダクト',
+        memo: '更新されたメモ',
+        githubId: 'updated-taro',
+        tagIds: ['tag-1'], // React のみ
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson).toBeDefined();
+      expect(updatedPerson.id).toBe('test-person-1');
+      expect(updatedPerson.name).toBe('更新された太郎');
+      expect(updatedPerson.handle).toBe('@updated_taro');
+      expect(updatedPerson.company).toBe('更新された会社');
+      expect(updatedPerson.position).toBe('更新されたポジション');
+      expect(updatedPerson.description).toBe('更新された説明');
+      expect(updatedPerson.productName).toBe('更新されたプロダクト');
+      expect(updatedPerson.memo).toBe('更新されたメモ');
+      expect(updatedPerson.githubId).toBe('updated-taro');
+      expect(updatedPerson.updatedAt).toBeInstanceOf(Date);
+      expect(updatedPerson.updatedAt.getTime()).toBeGreaterThan(
+        new Date('2025-01-01').getTime()
+      );
+    });
+
+    it('タグを適切に更新できる', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: 'テスト太郎',
+        tagIds: ['tag-3', 'tag-4'], // UI/UX, Figma に変更
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson.tags).toHaveLength(2);
+      expect(updatedPerson.tags.map(tag => tag.id)).toEqual(['tag-3', 'tag-4']);
+      expect(updatedPerson.tags.map(tag => tag.name)).toEqual(['UI/UX', 'Figma']);
+    });
+
+    it('タグを空にできる', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: 'テスト太郎',
+        tagIds: [], // タグを空にする
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson.tags).toHaveLength(0);
+    });
+
+    it('tagIdsが未指定の場合、タグは空になる', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: 'テスト太郎',
+        // tagIdsを指定しない
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson.tags).toHaveLength(0);
+    });
+
+    it('存在しないタグIDを指定した場合、そのタグは無視される', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: 'テスト太郎',
+        tagIds: ['tag-1', 'tag-999', 'tag-2'], // tag-999は存在しない
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson.tags).toHaveLength(2);
+      expect(updatedPerson.tags.map(tag => tag.id)).toEqual(['tag-1', 'tag-2']);
+    });
+
+    it('null値のフィールドを適切に処理できる', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: 'テスト太郎',
+        handle: null,
+        company: null,
+        position: null,
+        description: null,
+        productName: null,
+        memo: null,
+        githubId: null,
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson.name).toBe('テスト太郎');
+      expect(updatedPerson.handle).toBeNull();
+      expect(updatedPerson.company).toBeNull();
+      expect(updatedPerson.position).toBeNull();
+      expect(updatedPerson.description).toBeNull();
+      expect(updatedPerson.productName).toBeNull();
+      expect(updatedPerson.memo).toBeNull();
+      expect(updatedPerson.githubId).toBeNull();
+    });
+
+    it('名前の前後の空白が自動的にトリムされる', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: '  更新された太郎  ',
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson.name).toBe('更新された太郎');
+    });
+
+    it('既存のeventsとrelationsが保持される', async () => {
+      // Arrange（準備）
+      // まず既存のイベントとリレーションを持つ人物を作成
+      const personWithData: PersonWithRelations = {
+        ...mockTestPersons[0],
+        events: [
+          { id: 'event-1', name: 'テストイベント', date: new Date('2025-01-01'), location: 'テスト会場' },
+        ],
+        relations: [
+          { id: 'relation-1', sourceId: 'test-person-1', targetId: 'test-person-2', relationType: 'colleague', createdAt: new Date('2025-01-01') },
+        ],
+      };
+      
+      PersonService.clearMockData();
+      PersonService.addMockData([personWithData]);
+
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: '更新された太郎',
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson.events).toHaveLength(1);
+      expect(updatedPerson.events[0].name).toBe('テストイベント');
+      expect(updatedPerson.relations).toHaveLength(1);
+      expect(updatedPerson.relations[0].relationType).toBe('colleague');
+    });
+
+    it('存在しない人物IDの場合、エラーが発生する', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'non-existent-person',
+        name: 'テスト太郎',
+      };
+
+      // Act & Assert（実行と検証）
+      await expect(PersonService.update(updateData)).rejects.toThrow(
+        '指定された人物が見つかりません'
+      );
+    });
+
+    it('空の名前の場合、エラーが発生する', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: '',
+      };
+
+      // Act & Assert（実行と検証）
+      await expect(PersonService.update(updateData)).rejects.toThrow(
+        '名前は必須項目です'
+      );
+    });
+
+    it('空白のみの名前の場合、エラーが発生する', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: '   ',
+      };
+
+      // Act & Assert（実行と検証）
+      await expect(PersonService.update(updateData)).rejects.toThrow(
+        '名前は必須項目です'
+      );
+    });
+
+    it('更新後のデータが実際に保存される', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: '更新された太郎',
+        company: '更新された会社',
+      };
+
+      // Act（実行）
+      await PersonService.update(updateData);
+
+      // Assert（検証）
+      const retrievedPerson = await PersonService.findById('test-person-1');
+      expect(retrievedPerson).toBeDefined();
+      expect(retrievedPerson?.name).toBe('更新された太郎');
+      expect(retrievedPerson?.company).toBe('更新された会社');
+    });
+
+    it('複数のタグを同時に更新できる', async () => {
+      // Arrange（準備）
+      const updateData: UpdatePersonData = {
+        id: 'test-person-1',
+        name: 'テスト太郎',
+        tagIds: ['tag-1', 'tag-2', 'tag-3', 'tag-4'], // 4つのタグを設定
+      };
+
+      // Act（実行）
+      const updatedPerson = await PersonService.update(updateData);
+
+      // Assert（検証）
+      expect(updatedPerson.tags).toHaveLength(4);
+      expect(updatedPerson.tags.map(tag => tag.id)).toEqual(['tag-1', 'tag-2', 'tag-3', 'tag-4']);
+      expect(updatedPerson.tags.map(tag => tag.name)).toEqual(['React', 'TypeScript', 'UI/UX', 'Figma']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- PersonService.update関数が未実装によるエラーを修正
- タグを追加・削除した状態での人物編集時のクラッシュを解決

## 問題
編集画面でタグを追加・削除して編集完了ボタンを押すと以下のエラーが発生：
```
ERROR  Person update error: [TypeError: _sqliteServices.PersonService.update is not a function (it is undefined)]
LOG  新規タグを追加: aaaaaaa
```

## 原因
- PersonService.tsにupdate関数が実装されていなかった
- UpdatePersonData型定義も不足していた
- PersonServiceオブジェクトのエクスポートにupdate関数が含まれていなかった

## 修正内容
### PersonService.ts
- **UpdatePersonData型定義を追加**
  - 人物更新用のデータ型
  - 必須フィールド(id, name)と任意フィールドを適切に定義

- **update関数を実装**
  - 既存人物データの更新機能
  - タグIDから実際のタグ情報を取得・設定
  - 既存のeventsとrelationsデータの保持
  - 適切なバリデーション（人物存在チェック、名前必須チェック）
  - 更新日時の自動更新

- **PersonServiceエクスポートオブジェクトにupdate関数を追加**

### テスト追加
- **13項目の包括的なテストケースを追加**
  - 基本的な更新機能
  - タグ管理（追加・削除・更新・空にする）
  - エラーハンドリング
  - データ永続化の確認
  - 既存データの保持確認

## 技術的詳細
### update関数の主な機能
1. **データ更新**: 人物の基本情報を更新
2. **タグ管理**: TagService.findByIdを使用してタグIDからタグ情報を取得
3. **データ保持**: 既存のeventsとrelationsを保持
4. **バリデーション**: 人物存在確認、名前の必須チェック
5. **自動処理**: 名前のトリム、更新日時の自動設定

### 型安全性
- UpdatePersonData型でnull許可フィールドを適切に定義
- 既存のPersonWithRelations型との互換性を確保

## Test plan
- [x] PersonService.updateの全機能テスト（13項目）
- [x] 編集画面でのタグ追加・削除が正常に動作
- [x] 人物情報の更新が正常に完了
- [x] 既存データ（events, relations）の保持確認
- [x] エラーハンドリングの動作確認
- [x] Lintエラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)