### PR TITLE
feat: 人物詳細画面に削除機能を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat | jq -r '\"display notification \\\"\" + .message + \"\\\" with title \\\"\" + .title + \"\\\" sound name \\\"Glass\\\"\"' | xargs -I {} osascript -e '{}'"
+          }
+        ]
+      }
+    ]
+  },
   "toolChoice": {
     "allowedTools": {
       "bash": {

--- a/ReMeet/app/person-detail.tsx
+++ b/ReMeet/app/person-detail.tsx
@@ -14,6 +14,7 @@ import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { PersonService } from "@/database/sqlite-services";
 import type { PersonWithRelations } from "@/database/sqlite-types";
+import { usePersonMutations } from "@/hooks/usePersonMutations";
 
 /**
  * 人物詳細画面
@@ -24,6 +25,7 @@ export default function PersonDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const borderColor = useThemeColor({}, "border");
+  const { deletePersonMutation } = usePersonMutations();
 
   // TanStack Queryを使用して人物データを取得
   const {
@@ -104,6 +106,31 @@ export default function PersonDetailScreen() {
     );
   }
 
+  // 削除確認アラートとハンドラー
+  const handleDeletePress = () => {
+    Alert.alert(
+      "削除確認",
+      "本当にこの人物を削除しますか？",
+      [
+        {
+          text: "キャンセル",
+          style: "cancel",
+        },
+        {
+          text: "削除する",
+          style: "destructive",
+          onPress: () => {
+            deletePersonMutation.mutate(id, {
+              onSuccess: () => {
+                router.back();
+              },
+            });
+          },
+        },
+      ]
+    );
+  };
+
   return (
     <>
       <Stack.Screen
@@ -140,6 +167,20 @@ export default function PersonDetailScreen() {
           testID="person-detail-scroll-view"
         >
           <PersonDetailCard person={person} borderColor={borderColor} />
+          
+          {/* 削除ボタン */}
+          <View style={styles.deleteButtonContainer}>
+            <TouchableOpacity
+              style={styles.deleteButton}
+              onPress={handleDeletePress}
+              disabled={deletePersonMutation.isPending}
+              testID="delete-person-button"
+            >
+              <ThemedText style={styles.deleteButtonText}>
+                {deletePersonMutation.isPending ? "削除中..." : "人物を削除"}
+              </ThemedText>
+            </TouchableOpacity>
+          </View>
         </ScrollView>
       </ThemedView>
     </>
@@ -424,5 +465,30 @@ const styles = StyleSheet.create({
     fontSize: 14,
     opacity: 0.5,
     marginBottom: 2,
+  },
+  deleteButtonContainer: {
+    marginTop: 32,
+    marginBottom: 20,
+  },
+  deleteButton: {
+    backgroundColor: '#FF3B30',
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  deleteButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
   },
 });


### PR DESCRIPTION
## Summary
- 人物詳細画面の一番下に削除ボタンを配置
- 削除確認アラート（「本当に削除しますか？」）を実装
- TanStack Queryを使用した削除処理とJotai更新ロジックを統合

## Test plan
- [ ] 人物詳細画面で削除ボタンが一番下に表示されることを確認
- [ ] 削除ボタン押下時に確認アラートが表示されることを確認
- [ ] 「キャンセル」選択時に削除がキャンセルされることを確認
- [ ] 「削除する」選択時に人物が削除されることを確認
- [ ] 削除後に人物リストが更新されることを確認
- [ ] 削除後に前の画面に自動的に戻ることを確認
- [ ] 削除中にローディング状態が表示されることを確認
- [ ] エラー時に適切なアラートが表示されることを確認