### PR TITLE
fix: 削除ボタンの角を全て丸くするように修正

### DIFF
--- a/ReMeet/components/ui/SwipeablePersonCard.tsx
+++ b/ReMeet/components/ui/SwipeablePersonCard.tsx
@@ -168,8 +168,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     width: 80,
     height: '100%',
-    borderTopRightRadius: 12,
-    borderBottomRightRadius: 12,
+    borderRadius: 12,
   },
   deleteButtonText: {
     color: '#FFFFFF',


### PR DESCRIPTION
## 修正内容

- SwipeablePersonCard の削除ボタンの角を全て丸くするように修正
- `borderTopRightRadius` と `borderBottomRightRadius` を `borderRadius` に変更

## 変更理由

- ユーザーの要望により、削除ボタンの角が全て丸くなるように修正
- 現在は右側の角のみが丸くなっていたが、全ての角を統一的に丸くすることでより良いUIを実現

## 影響範囲

- ホーム画面の人物カードの左スワイプ削除ボタンのみ
- 機能的な変更はなし（デザインのみの修正）