### PR TITLE
feat: スワイプ削除の自動閉じ機能を追加

### DIFF
--- a/ReMeet/app/(tabs)/people.tsx
+++ b/ReMeet/app/(tabs)/people.tsx
@@ -29,6 +29,16 @@ export default function HomeScreen() {
   const [openSwipeId, setOpenSwipeId] = useState<string | null>(null);
   // 各カードのrefを保持するMap
   const swipeableRefs = useRef<Map<string, any>>(new Map());
+  // スワイプが開く前に他のカードを閉じる
+  const closeOtherSwipeables = useRef<(excludeId: string) => void>();
+  
+  closeOtherSwipeables.current = (excludeId: string) => {
+    swipeableRefs.current.forEach((ref, id) => {
+      if (id !== excludeId && ref?.close) {
+        ref.close();
+      }
+    });
+  };
   
   // Jotai Atomsから状態を取得
   const [people, setPeople] = useAtom(peopleAtom);
@@ -179,12 +189,11 @@ export default function HomeScreen() {
               person={person}
               onPress={() => handlePersonDetail(person.id)}
               onDelete={() => handleSwipeDelete(person)}
+              onSwipeStartDrag={() => {
+                // ドラッグ開始時に全ての他のカードを閉じる
+                closeOtherSwipeables.current?.(person.id);
+              }}
               onSwipeOpen={() => {
-                // 他の開いているカードを閉じる
-                if (openSwipeId && openSwipeId !== person.id) {
-                  const prevRef = swipeableRefs.current.get(openSwipeId);
-                  prevRef?.close();
-                }
                 setOpenSwipeId(person.id);
               }}
               onSwipeClose={() => {

--- a/ReMeet/components/ui/SwipeablePersonCard.tsx
+++ b/ReMeet/components/ui/SwipeablePersonCard.tsx
@@ -16,13 +16,14 @@ interface SwipeablePersonCardProps {
   onDelete: () => void;
   onSwipeOpen?: () => void;
   onSwipeClose?: () => void;
+  onSwipeStartDrag?: () => void;
 }
 
 // forwardRefを使用して外部からrefを受け取れるようにする
 export const SwipeablePersonCard = React.forwardRef<
   Swipeable,
   SwipeablePersonCardProps
->(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose }, ref) => {
+>(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose, onSwipeStartDrag }, ref) => {
   // 内部refと外部refを統合
   const internalRef = useRef<Swipeable>(null);
   const swipeableRef = (ref as React.RefObject<Swipeable>) || internalRef;
@@ -47,8 +48,9 @@ export const SwipeablePersonCard = React.forwardRef<
       ref={typeof ref === 'object' ? ref : internalRef}
       renderRightActions={renderRightActions}
       rightThreshold={40}
-      onSwipeableWillOpen={onSwipeOpen}  // onSwipeableOpenからonSwipeableWillOpenに変更
+      onSwipeableOpen={onSwipeOpen}
       onSwipeableClose={onSwipeClose}
+      onSwipeableOpenStartDrag={onSwipeStartDrag}  // ドラッグ開始時に呼ばれる
       testID={`swipeable-person-card-${person.id}`}
     >
       <TouchableOpacity

--- a/ReMeet/components/ui/SwipeablePersonCard.tsx
+++ b/ReMeet/components/ui/SwipeablePersonCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 import { ThemedView } from '@/components/ThemedView';
@@ -14,13 +14,18 @@ interface SwipeablePersonCardProps {
   person: PersonWithRelations;
   onPress: () => void;
   onDelete: () => void;
+  onSwipeOpen?: () => void;
+  onSwipeClose?: () => void;
 }
 
-export const SwipeablePersonCard: React.FC<SwipeablePersonCardProps> = ({
-  person,
-  onPress,
-  onDelete,
-}) => {
+// forwardRefを使用して外部からrefを受け取れるようにする
+export const SwipeablePersonCard = React.forwardRef<
+  Swipeable,
+  SwipeablePersonCardProps
+>(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose }, ref) => {
+  // 内部refと外部refを統合
+  const internalRef = useRef<Swipeable>(null);
+  const swipeableRef = (ref as React.RefObject<Swipeable>) || internalRef;
   /**
    * 右側に表示される削除アクション
    * 画像の通り赤いボタンで「削除」テキストを表示
@@ -39,13 +44,25 @@ export const SwipeablePersonCard: React.FC<SwipeablePersonCardProps> = ({
 
   return (
     <Swipeable
+      ref={typeof ref === 'object' ? ref : internalRef}
       renderRightActions={renderRightActions}
       rightThreshold={40}
+      onSwipeableOpen={onSwipeOpen}
+      onSwipeableClose={onSwipeClose}
       testID={`swipeable-person-card-${person.id}`}
     >
       <TouchableOpacity
         style={styles.personCard}
-        onPress={onPress}
+        onPress={() => {
+          // スワイプが開いている場合は閉じる
+          if (typeof ref === 'object' && ref?.current) {
+            ref.current.close();
+          } else {
+            internalRef.current?.close();
+          }
+          // 元のonPressを実行
+          onPress();
+        }}
         testID={`person-card-${person.id}`}
       >
         <ThemedView style={styles.personCardContent}>
@@ -90,7 +107,10 @@ export const SwipeablePersonCard: React.FC<SwipeablePersonCardProps> = ({
       </TouchableOpacity>
     </Swipeable>
   );
-};
+});
+
+// displayNameを設定
+SwipeablePersonCard.displayName = 'SwipeablePersonCard';
 
 const styles = StyleSheet.create({
   personCard: {

--- a/ReMeet/components/ui/SwipeablePersonCard.tsx
+++ b/ReMeet/components/ui/SwipeablePersonCard.tsx
@@ -14,16 +14,15 @@ interface SwipeablePersonCardProps {
   person: PersonWithRelations;
   onPress: () => void;
   onDelete: () => void;
-  onSwipeOpen?: () => void;
+  onSwipeOpen?: (ref: any) => void;
   onSwipeClose?: () => void;
-  onSwipeStartDrag?: () => void;
 }
 
 // forwardRefを使用して外部からrefを受け取れるようにする
 export const SwipeablePersonCard = React.forwardRef<
   Swipeable,
   SwipeablePersonCardProps
->(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose, onSwipeStartDrag }, ref) => {
+>(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose }, ref) => {
   // 内部refと外部refを統合
   const internalRef = useRef<Swipeable>(null);
   const swipeableRef = (ref as React.RefObject<Swipeable>) || internalRef;
@@ -48,9 +47,11 @@ export const SwipeablePersonCard = React.forwardRef<
       ref={typeof ref === 'object' ? ref : internalRef}
       renderRightActions={renderRightActions}
       rightThreshold={40}
-      onSwipeableOpen={onSwipeOpen}
+      onSwipeableOpen={() => {
+        const currentRef = typeof ref === 'object' && ref?.current ? ref.current : internalRef.current;
+        onSwipeOpen?.(currentRef);
+      }}
       onSwipeableClose={onSwipeClose}
-      onSwipeableOpenStartDrag={onSwipeStartDrag}  // ドラッグ開始時に呼ばれる
       testID={`swipeable-person-card-${person.id}`}
     >
       <TouchableOpacity

--- a/ReMeet/components/ui/SwipeablePersonCard.tsx
+++ b/ReMeet/components/ui/SwipeablePersonCard.tsx
@@ -47,7 +47,7 @@ export const SwipeablePersonCard = React.forwardRef<
       ref={typeof ref === 'object' ? ref : internalRef}
       renderRightActions={renderRightActions}
       rightThreshold={40}
-      onSwipeableOpen={onSwipeOpen}
+      onSwipeableWillOpen={onSwipeOpen}  // onSwipeableOpenからonSwipeableWillOpenに変更
       onSwipeableClose={onSwipeClose}
       testID={`swipeable-person-card-${person.id}`}
     >

--- a/ReMeet/jest.setup.js
+++ b/ReMeet/jest.setup.js
@@ -45,15 +45,16 @@ jest.mock('@/components/ui/IconSymbol', () => ({
 }));
 
 // SwipeablePersonCard のモック
-jest.mock('@/components/ui/SwipeablePersonCard', () => ({
-  SwipeablePersonCard: ({ person, onPress, onDelete, ...props }) => {
-    const React = require('react');
-    const { TouchableOpacity, View, Text } = require('react-native');
-    
+jest.mock('@/components/ui/SwipeablePersonCard', () => {
+  const React = require('react');
+  const { TouchableOpacity, View, Text } = require('react-native');
+  
+  // forwardRefで定義されたコンポーネントのモック
+  const SwipeablePersonCard = React.forwardRef(({ person, onPress, onDelete, ...props }, ref) => {
     // 元のPersonCardと同様の構造を再現
     return React.createElement(
       View,
-      { ...props, testID: `swipeable-person-card-${person.id}` },
+      { ...props, testID: `swipeable-person-card-${person.id}`, ref },
       React.createElement(
         TouchableOpacity,
         { 
@@ -75,8 +76,12 @@ jest.mock('@/components/ui/SwipeablePersonCard', () => ({
         ]).flat() : [])
       )
     );
-  },
-}));
+  });
+  
+  SwipeablePersonCard.displayName = 'SwipeablePersonCard';
+  
+  return { SwipeablePersonCard };
+});
 
 // useSwipeDelete のモック
 jest.mock('@/hooks/useSwipeDelete', () => ({

--- a/ReMeet/jest.setup.js
+++ b/ReMeet/jest.setup.js
@@ -50,7 +50,7 @@ jest.mock('@/components/ui/SwipeablePersonCard', () => {
   const { TouchableOpacity, View, Text } = require('react-native');
   
   // forwardRefで定義されたコンポーネントのモック
-  const SwipeablePersonCard = React.forwardRef(({ person, onPress, onDelete, ...props }, ref) => {
+  const SwipeablePersonCard = React.forwardRef(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose, onSwipeStartDrag, ...props }, ref) => {
     // 元のPersonCardと同様の構造を再現
     return React.createElement(
       View,

--- a/ReMeet/jest.setup.js
+++ b/ReMeet/jest.setup.js
@@ -50,7 +50,7 @@ jest.mock('@/components/ui/SwipeablePersonCard', () => {
   const { TouchableOpacity, View, Text } = require('react-native');
   
   // forwardRefで定義されたコンポーネントのモック
-  const SwipeablePersonCard = React.forwardRef(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose, onSwipeStartDrag, ...props }, ref) => {
+  const SwipeablePersonCard = React.forwardRef(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose, ...props }, ref) => {
     // 元のPersonCardと同様の構造を再現
     return React.createElement(
       View,


### PR DESCRIPTION
## 実装内容

ホーム画面の人物カードのスワイプ削除機能において、削除ボタン以外の領域をタップした時に自動的にスワイプを閉じる機能を追加しました。

## 変更詳細

### SwipeablePersonCardコンポーネントの改善
- forwardRefパターンを使用して外部からのスワイプ制御を可能に
- onSwipeOpen/onSwipeCloseコールバックを追加
- カードタップ時にスワイプを自動的に閉じる処理を追加

### people.tsxの改善  
- 開いているスワイプカードのIDを管理する状態を追加
- 各カードのrefをMapで管理
- ScrollViewの背景タップでスワイプを閉じる処理を追加
- 他のカードをスワイプした時に前のカードを自動的に閉じる

### テスト環境の修正
- jest.setup.jsでforwardRefパターンに対応したモックを作成

## 動作確認

- ✅ 削除ボタン以外の領域をタップするとスワイプが閉じる
- ✅ カード自体をタップしてもスワイプが閉じる
- ✅ 他のカードをスワイプすると前のカードが自動的に閉じる
- ✅ スクロールビューの背景をタップしてもスワイプが閉じる
- ✅ 全てのテストが通過