### PR TITLE
feat: スワイプ削除の即座な閉じ機能を改善

### DIFF
--- a/ReMeet/jest.setup.js
+++ b/ReMeet/jest.setup.js
@@ -51,10 +51,18 @@ jest.mock('@/components/ui/SwipeablePersonCard', () => {
   
   // forwardRefで定義されたコンポーネントのモック
   const SwipeablePersonCard = React.forwardRef(({ person, onPress, onDelete, onSwipeOpen, onSwipeClose, ...props }, ref) => {
+    // instantClose関数を含むモックref
+    React.useImperativeHandle(ref, () => ({
+      close: jest.fn(),
+      instantClose: jest.fn(),
+      openLeft: jest.fn(),
+      openRight: jest.fn(),
+    }));
+    
     // 元のPersonCardと同様の構造を再現
     return React.createElement(
       View,
-      { ...props, testID: `swipeable-person-card-${person.id}`, ref },
+      { ...props, testID: `swipeable-person-card-${person.id}` },
       React.createElement(
         TouchableOpacity,
         { 


### PR DESCRIPTION
## 概要
スワイプ削除ボタンが不安定に閉じる問題を解決し、別箇所タップやスクロール時に即座に（アニメーションなしで）閉じるように改善しました。

## 変更内容
- **ScrollView onScrollイベント追加**: スクロール中に削除ボタンを即座に閉じる
- **PanGestureHandler感度向上**: 縦スクロールの検出精度を向上（translationY > 3px、velocityY > 30px）
- **カードタップ時の改善**: SwipeablePersonCard内でのタップ時の即座閉じロジックを改善
- **instantClose関数の改善**: Animated値の直接操作ではなく、通常のclose()メソッドを使用してより安定した動作を実現

## テスト
- SwipeablePersonCardのテストが全て通過
- Lintチェックもパス

## 動作確認
- 別箇所タップ時: 削除ボタンが即座に閉じる
- スクロール時: 縦スクロール検出で削除ボタンが即座に閉じる
- カードタップ時: スワイプが開いている場合は先に閉じてからonPressを実行

## 関連ファイル
- `app/(tabs)/people.tsx`: ScrollViewのonScrollイベントとPanGestureHandlerの改善
- `components/ui/SwipeablePersonCard.tsx`: instantClose関数とタップ時の処理改善
- `jest.setup.js`: instantCloseメソッドのモック追加